### PR TITLE
fix: `kill` failed if the process already terminated

### DIFF
--- a/.changes/kill-already-terminated.md
+++ b/.changes/kill-already-terminated.md
@@ -1,0 +1,6 @@
+---
+"nsis_process": patch
+"nsis_tauri_utils": patch
+---
+
+Fix `KillProcessCurrentUser` and `KillProcess` may fails if the target processes are being terminated.

--- a/crates/nsis-process/src/lib.rs
+++ b/crates/nsis-process/src/lib.rs
@@ -6,6 +6,7 @@ use alloc::{borrow::ToOwned, vec, vec::Vec};
 use core::{ffi::c_void, mem, ops::Deref, ops::DerefMut, ptr};
 
 use nsis_plugin_api::*;
+use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER};
 use windows_sys::{
     w,
     Win32::{
@@ -34,7 +35,6 @@ use windows_sys::{
         },
     },
 };
-use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER};
 
 nsis_plugin!();
 

--- a/crates/nsis-process/src/lib.rs
+++ b/crates/nsis-process/src/lib.rs
@@ -175,7 +175,7 @@ fn kill(pid: u32) -> bool {
             // `OpenProcess` would fail with ERROR_ACCESS_DENIED instead.
             return error == ERROR_ACCESS_DENIED;
         }
-        return true;
+        true
     }
 }
 

--- a/crates/nsis-process/src/lib.rs
+++ b/crates/nsis-process/src/lib.rs
@@ -34,6 +34,7 @@ use windows_sys::{
         },
     },
 };
+use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER};
 
 nsis_plugin!();
 
@@ -158,8 +159,23 @@ unsafe fn belongs_to_user(user_sid: *mut c_void, pid: u32) -> bool {
 
 fn kill(pid: u32) -> bool {
     unsafe {
-        let handle = OwnedHandle::new(OpenProcess(PROCESS_TERMINATE, 0, pid));
-        TerminateProcess(*handle, 1) == TRUE
+        let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if handle.is_null() {
+            let error = GetLastError();
+            // ERROR_INVALID_PARAMETER will occur if the process is already terminated
+            return error == ERROR_INVALID_PARAMETER;
+        }
+
+        let handle = OwnedHandle::new(handle);
+        if TerminateProcess(*handle, 1) == FALSE {
+            let error = GetLastError();
+            // ERROR_ACCESS_DENIED will occur if the process is terminated
+            // between OpenProcess and TerminateProcess.
+            // If current process lacks permission to terminate process,
+            // `OpenProcess` would fail with ERROR_ACCESS_DENIED instead.
+            return error == ERROR_ACCESS_DENIED;
+        }
+        return true;
     }
 }
 


### PR DESCRIPTION
Fixing https://github.com/tauri-apps/tauri/issues/12309 but do not close because we need to release nsis-tauri-utils before