### PR TITLE
fix: KillProcess should push 0 when nothing found

### DIFF
--- a/.changes/kill-process-no-processes.md
+++ b/.changes/kill-process-no-processes.md
@@ -1,0 +1,6 @@
+---
+"nsis_process": patch
+"nsis_tauri_utils": patch
+---
+
+`KillProcess` and `KillProcessCurrentUser` should be pushing 0 to the stack instead of 1 when no processes were found

--- a/.changes/kill-process-no-processes.md
+++ b/.changes/kill-process-no-processes.md
@@ -3,4 +3,4 @@
 "nsis_tauri_utils": patch
 ---
 
-`KillProcess` and `KillProcessCurrentUser` should be pushing 0 to the stack instead of 1 when no processes were found
+`KillProcess` and `KillProcessCurrentUser` will now be pushing 2 to the stack instead of 1 when no processes were found

--- a/crates/nsis-plugin-api/src/lib.rs
+++ b/crates/nsis-plugin-api/src/lib.rs
@@ -53,8 +53,9 @@ pub unsafe fn exdll_init(string_size: c_int, variables: *mut wchar_t, stacktop: 
     G_STACKTOP = stacktop;
 }
 
-pub const ONE: &[u16; 2] = &[49, 0];
 pub const ZERO: &[u16; 2] = &[48, 0];
+pub const ONE: &[u16; 2] = &[49, 0];
+pub const TWO: &[u16; 2] = &[50, 0];
 pub const NEGATIVE_ONE: &[u16; 3] = &[45, 49, 0];
 
 #[derive(Debug)]

--- a/crates/nsis-process/src/lib.rs
+++ b/crates/nsis-process/src/lib.rs
@@ -40,9 +40,9 @@ use windows_sys::{
 
 /// Test if there is a running process with the given name, skipping processes with the host's pid. The input and process names are case-insensitive.
 ///
-/// # Safety
+/// This function takes 1 string on the stack as the parameter:
 ///
-/// This function always expects 1 string on the stack ($1: name) and will panic otherwise.
+/// - $1: name
 #[nsis_fn]
 fn FindProcess() -> Result<(), Error> {
     let name = popstr()?;
@@ -56,9 +56,9 @@ fn FindProcess() -> Result<(), Error> {
 
 /// Test if there is a running process with the given name that belongs to the current user, skipping processes with the host's pid. The input and process names are case-insensitive.
 ///
-/// # Safety
+/// This function takes 1 string on the stack as the parameter:
 ///
-/// This function always expects 1 string on the stack ($1: name) and will panic otherwise.
+/// - $1: name
 #[nsis_fn]
 fn FindProcessCurrentUser() -> Result<(), Error> {
     let name = popstr()?;
@@ -84,14 +84,24 @@ fn FindProcessCurrentUser() -> Result<(), Error> {
 
 /// Kill all running process with the given name, skipping processes with the host's pid. The input and process names are case-insensitive.
 ///
-/// # Safety
+/// Returns:
 ///
-/// This function always expects 1 string on the stack ($1: name) and will panic otherwise.
+/// - 0: When one or more processes matching the name were found and killed successfully
+/// - 1: When one or more processes matching the name were found but not all were killed successfully
+/// - 2: When no processes matching the name were found
+///
+/// This function takes 1 string on the stack as the parameter:
+///
+/// - $1: name
 #[nsis_fn]
 fn KillProcess() -> Result<(), Error> {
     let name = popstr()?;
 
     let processes = get_processes(&name);
+
+    if processes.is_empty() {
+        return push(TWO);
+    }
 
     if processes.into_iter().all(kill) {
         push(ZERO)
@@ -102,9 +112,15 @@ fn KillProcess() -> Result<(), Error> {
 
 /// Kill all running process with the given name that belong to the current user, skipping processes with the host's pid. The input and process names are case-insensitive.
 ///
-/// # Safety
+/// Returns:
 ///
-/// This function always expects 1 string on the stack ($1: name) and will panic otherwise.
+/// - 0: When one or more processes matching the name were found and killed successfully
+/// - 1: When one or more processes matching the name were found but not all were killed successfully
+/// - 2: When no processes matching the name were found
+///
+/// This function takes 1 string on the stack as the parameter:
+///
+/// - $1: name
 #[nsis_fn]
 fn KillProcessCurrentUser() -> Result<(), Error> {
     let name = popstr()?;
@@ -112,7 +128,7 @@ fn KillProcessCurrentUser() -> Result<(), Error> {
     let processes = get_processes(&name);
 
     if processes.is_empty() {
-        return push(ZERO);
+        return push(TWO);
     }
 
     let success = if let Some(user_sid) = get_sid(GetCurrentProcessId()) {
@@ -133,9 +149,10 @@ fn KillProcessCurrentUser() -> Result<(), Error> {
 
 /// Run program as unelevated user
 ///
-/// Needs 2 strings on the stack
-/// $1: program
-/// $2: arguments
+/// This function takes 2 strings on the stack as parameters:
+///
+/// - $1: program
+/// - $2: arguments
 #[nsis_fn]
 fn RunAsUser() -> Result<(), Error> {
     let program = popstr()?;

--- a/crates/nsis-process/src/lib.rs
+++ b/crates/nsis-process/src/lib.rs
@@ -93,7 +93,7 @@ fn KillProcess() -> Result<(), Error> {
 
     let processes = get_processes(&name);
 
-    if !processes.is_empty() && processes.into_iter().all(kill) {
+    if processes.into_iter().all(kill) {
         push(ZERO)
     } else {
         push(ONE)
@@ -112,7 +112,7 @@ fn KillProcessCurrentUser() -> Result<(), Error> {
     let processes = get_processes(&name);
 
     if processes.is_empty() {
-        return push(ONE);
+        return push(ZERO);
     }
 
     let success = if let Some(user_sid) = get_sid(GetCurrentProcessId()) {


### PR DESCRIPTION
`KillProcess` and `KillProcessCurrentUser` will be pushing 0 to the stack instead of 1 when no processes were found

The idea behind `KillProcess` is to kill all the processes with the given name, so if we didn't find anything, it should just return success since everything with that name are now killed, at least that's the case for our use cases (or alternatively we could return something else to indicate this)

Fix

https://github.com/tauri-apps/tauri/issues/14400