### PR TITLE
fix: program launched by `RunAsUser` can't query its own handle

### DIFF
--- a/.changes/run-as-user-token.md
+++ b/.changes/run-as-user-token.md
@@ -1,0 +1,6 @@
+---
+nsis_process: patch
+nsis_tauri_utils: patch
+---
+
+Use an alternative method `CreateProcessWithTokenW` to run programs as user, this fixed a problem that the program launched with the previous method can't query its own handle

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT or Apache-2.0"
 nsis-plugin-api = { path = "./crates/nsis-plugin-api" }
 
 [workspace.dependencies.windows-sys]
-version = "0.61.0"
+version = "0.61.2"
 features = [
     "Win32_Foundation",
     "Win32_Globalization",

--- a/crates/nsis-process/src/lib.rs
+++ b/crates/nsis-process/src/lib.rs
@@ -8,27 +8,30 @@ extern crate alloc;
 use alloc::{borrow::ToOwned, vec, vec::Vec};
 use core::{ffi::c_void, mem, ops::Deref, ops::DerefMut, ptr};
 
-use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER};
 use windows_sys::{
+    core::PCWSTR,
     w,
     Win32::{
         Foundation::{
-            CloseHandle, GetLastError, ERROR_ELEVATION_REQUIRED, ERROR_INSUFFICIENT_BUFFER, FALSE,
-            HANDLE, TRUE,
+            CloseHandle, GetLastError, ERROR_ACCESS_DENIED, ERROR_ELEVATION_REQUIRED,
+            ERROR_INVALID_PARAMETER, ERROR_NOT_ALL_ASSIGNED, FALSE, HANDLE, LUID, TRUE,
         },
-        Security::{EqualSid, GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER},
+        Security::{
+            AdjustTokenPrivileges, DuplicateTokenEx, EqualSid, GetTokenInformation,
+            LookupPrivilegeValueW, SecurityAnonymous, TokenElevation, TokenPrimary, TokenUser,
+            LUID_AND_ATTRIBUTES, SE_IMPERSONATE_NAME, SE_PRIVILEGE_ENABLED, TOKEN_ADJUST_DEFAULT,
+            TOKEN_ADJUST_PRIVILEGES, TOKEN_ADJUST_SESSIONID, TOKEN_ASSIGN_PRIMARY, TOKEN_DUPLICATE,
+            TOKEN_ELEVATION, TOKEN_PRIVILEGES, TOKEN_QUERY, TOKEN_USER,
+        },
         System::{
             Diagnostics::ToolHelp::{
                 CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
                 TH32CS_SNAPPROCESS,
             },
             Threading::{
-                CreateProcessW, GetCurrentProcessId, InitializeProcThreadAttributeList,
-                OpenProcess, OpenProcessToken, TerminateProcess, UpdateProcThreadAttribute,
-                CREATE_NEW_PROCESS_GROUP, CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT,
-                LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_CREATE_PROCESS, PROCESS_INFORMATION,
-                PROCESS_QUERY_INFORMATION, PROCESS_TERMINATE, PROC_THREAD_ATTRIBUTE_PARENT_PROCESS,
-                STARTUPINFOEXW, STARTUPINFOW,
+                CreateProcessWithTokenW, GetCurrentProcess, GetCurrentProcessId, OpenProcess,
+                OpenProcessToken, TerminateProcess, PROCESS_INFORMATION, PROCESS_QUERY_INFORMATION,
+                PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, STARTUPINFOW,
             },
         },
         UI::{
@@ -262,96 +265,184 @@ fn get_processes(name: &str) -> Vec<u32> {
     processes
 }
 
+unsafe fn is_elevated(process: HANDLE) -> bool {
+    let mut token_handle: HANDLE = ptr::null_mut();
+
+    if OpenProcessToken(process, TOKEN_QUERY, &mut token_handle) == FALSE {
+        return false;
+    }
+
+    let _token = OwnedHandle::new(token_handle);
+
+    let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
+    let mut size: u32 = 0;
+
+    let result = GetTokenInformation(
+        token_handle,
+        TokenElevation,
+        &mut elevation as *mut _ as *mut _,
+        mem::size_of::<TOKEN_ELEVATION>() as u32,
+        &mut size,
+    );
+    result != FALSE && elevation.TokenIsElevated != 0
+}
+
+unsafe fn set_privilege(process: HANDLE, privilege: PCWSTR, enable: bool) -> Option<bool> {
+    let mut token: HANDLE = ptr::null_mut();
+    if OpenProcessToken(process, TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, &mut token) == FALSE {
+        return None;
+    }
+    let token = OwnedHandle::new(token);
+
+    let mut luid = LUID::default();
+    if LookupPrivilegeValueW(ptr::null(), privilege, &mut luid) == FALSE {
+        return None;
+    }
+
+    let token_privileges = TOKEN_PRIVILEGES {
+        PrivilegeCount: 1,
+        Privileges: [LUID_AND_ATTRIBUTES {
+            Luid: luid,
+            Attributes: if enable { SE_PRIVILEGE_ENABLED } else { 0 },
+        }],
+    };
+
+    let mut previous_state = TOKEN_PRIVILEGES::default();
+    let mut return_length = 0;
+    let result = AdjustTokenPrivileges(
+        *token,
+        FALSE,
+        &token_privileges,
+        mem::size_of::<TOKEN_PRIVILEGES>() as u32,
+        &mut previous_state,
+        &mut return_length,
+    );
+    if result == FALSE || GetLastError() == ERROR_NOT_ALL_ASSIGNED {
+        return None;
+    }
+
+    if previous_state.PrivilegeCount == 1 {
+        let was_enabled = (previous_state.Privileges[0].Attributes & SE_PRIVILEGE_ENABLED) != 0;
+        Some(was_enabled)
+    } else {
+        Some(enable)
+    }
+}
+
 /// Return true if success
 ///
-/// Ported from https://devblogs.microsoft.com/oldnewthing/20190425-00/?p=102443
+/// Ported from https://source.chromium.org/chromium/chromium/src/+/main:base/win/elevation_util.cc;drc=36e1c43ace542988d624bd1bc0813c184482d2ab;l=69
+/// Based on https://learn.microsoft.com/en-us/archive/blogs/aaron_margosis/faq-how-do-i-start-a-program-as-the-desktop-user-from-an-elevated-app
 unsafe fn run_as_user(program: &str, arguments: &str) -> bool {
+    let current_process = GetCurrentProcess();
+    if !is_elevated(current_process) {
+        // Launch directly if no admin access
+        return shell_execute(&encode_utf16(program), arguments);
+    }
+
     let hwnd = GetShellWindow();
     if hwnd.is_null() {
         return false;
     }
 
-    let mut proccess_id = 0;
-    if GetWindowThreadProcessId(hwnd, &mut proccess_id) == FALSE as u32 {
+    let mut process_id = 0;
+    if GetWindowThreadProcessId(hwnd, &mut process_id) == FALSE as u32 {
         return false;
     }
 
-    let process = OwnedHandle::new(OpenProcess(PROCESS_CREATE_PROCESS, FALSE, proccess_id));
+    let process = OwnedHandle::new(OpenProcess(
+        PROCESS_QUERY_LIMITED_INFORMATION,
+        FALSE,
+        process_id,
+    ));
     if process.is_invalid() {
         return false;
     }
 
-    let mut size = 0;
-    if !(InitializeProcThreadAttributeList(ptr::null_mut(), 1, 0, &mut size) == FALSE
-        && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
-    {
+    let privilege = SE_IMPERSONATE_NAME;
+    let Some(enabled_previously) = set_privilege(current_process, privilege, true) else {
+        return false;
+    };
+    let _impersonate_guard = RevertPrivilegeOnDrop {
+        process: current_process,
+        privilege,
+        previous_state: enabled_previously,
+    };
+
+    let mut handle_token: HANDLE = ptr::null_mut();
+    if OpenProcessToken(*process, TOKEN_QUERY | TOKEN_DUPLICATE, &mut handle_token) == FALSE {
         return false;
     }
+    let handle_token = OwnedHandle::new(handle_token);
 
-    let mut buffer = vec![0u8; size];
-    let attribute_list = buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
-    if InitializeProcThreadAttributeList(attribute_list, 1, 0, &mut size) == FALSE {
-        return false;
-    }
-
-    if UpdateProcThreadAttribute(
-        attribute_list,
-        0,
-        PROC_THREAD_ATTRIBUTE_PARENT_PROCESS as _,
-        &*process as *const _ as _,
-        mem::size_of::<HANDLE>(),
-        ptr::null_mut(),
+    let mut handle_new_token: HANDLE = ptr::null_mut();
+    if DuplicateTokenEx(
+        *handle_token,
+        TOKEN_QUERY
+            | TOKEN_ASSIGN_PRIMARY
+            | TOKEN_DUPLICATE
+            | TOKEN_ADJUST_DEFAULT
+            | TOKEN_ADJUST_SESSIONID,
         ptr::null(),
+        SecurityAnonymous,
+        TokenPrimary,
+        &mut handle_new_token,
     ) == FALSE
     {
         return false;
     }
+    let handle_new_token = OwnedHandle::new(handle_new_token);
 
-    let startup_info = STARTUPINFOEXW {
-        StartupInfo: STARTUPINFOW {
-            cb: mem::size_of::<STARTUPINFOEXW>() as _,
-            ..mem::zeroed()
-        },
-        lpAttributeList: attribute_list,
-    };
-    let mut process_info: PROCESS_INFORMATION = mem::zeroed();
+    let program_wide = encode_utf16(program);
     let mut command_line = "\"".to_owned() + program + "\"";
     if !arguments.is_empty() {
         command_line.push(' ');
         command_line.push_str(arguments);
     }
+    let mut command_line_wide = encode_utf16(&command_line);
 
-    let program_wide = encode_utf16(program);
+    let startup_info = STARTUPINFOW {
+        cb: mem::size_of::<STARTUPINFOW>() as u32,
+        ..mem::zeroed()
+    };
+    let mut process_info: PROCESS_INFORMATION = mem::zeroed();
 
-    if CreateProcessW(
+    let success = CreateProcessWithTokenW(
+        *handle_new_token,
+        0,
         program_wide.as_ptr(),
-        encode_utf16(&command_line).as_mut_ptr(),
+        command_line_wide.as_mut_ptr(),
+        0,
         ptr::null(),
         ptr::null(),
-        FALSE,
-        CREATE_UNICODE_ENVIRONMENT | CREATE_NEW_PROCESS_GROUP | EXTENDED_STARTUPINFO_PRESENT,
-        ptr::null(),
-        ptr::null(),
-        &startup_info as *const _ as _,
+        &startup_info,
         &mut process_info,
-    ) != FALSE
-    {
+    );
+
+    if success != FALSE {
         CloseHandle(process_info.hProcess);
         CloseHandle(process_info.hThread);
         true
     } else if GetLastError() == ERROR_ELEVATION_REQUIRED {
-        let result = ShellExecuteW(
-            ptr::null_mut(),
-            w!("open"),
-            program_wide.as_ptr(),
-            encode_utf16(&command_line).as_ptr(),
-            ptr::null(),
-            SW_SHOW,
-        );
-        result as isize > 32
+        shell_execute(&program_wide, arguments)
     } else {
         false
     }
+}
+
+fn shell_execute(program_wide: &[u16], arguments: &str) -> bool {
+    let arguments_wide = encode_utf16(arguments);
+    let result = unsafe {
+        ShellExecuteW(
+            ptr::null_mut(),
+            w!("open"),
+            program_wide.as_ptr(),
+            arguments_wide.as_ptr(),
+            ptr::null(),
+            SW_SHOW,
+        )
+    };
+    result as isize > 32
 }
 
 struct OwnedHandle(HANDLE);
@@ -385,6 +476,20 @@ impl Deref for OwnedHandle {
 impl DerefMut for OwnedHandle {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+struct RevertPrivilegeOnDrop {
+    process: *mut c_void,
+    privilege: *const u16,
+    previous_state: bool,
+}
+
+impl Drop for RevertPrivilegeOnDrop {
+    fn drop(&mut self) {
+        unsafe {
+            set_privilege(self.process, self.privilege, self.previous_state);
+        };
     }
 }
 


### PR DESCRIPTION
We're currently using `ipc-channel` in our app and the program launched by the installer through `RunAsUser` will hit this panic `thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0'`, which is caused by unable to open its own process handle, this can be tested by launching a program that calls `OpenProcess(PROCESS_DUP_HANDLE, false, GetCurrentProcessId())`

This probably also explained the CI test failure:  https://github.com/tauri-apps/nsis-tauri-utils/actions/runs/19056995930/job/54429349735 

For more details, see the comment below in that blog:  https://devblogs.microsoft.com/oldnewthing/20190425-00/?p=102443&commentid=135186#comment-135186