### PR TITLE
fix(test): assert `run_as_user` result in `spawn_cmd`

### DIFF
--- a/crates/nsis-process/src/lib.rs
+++ b/crates/nsis-process/src/lib.rs
@@ -14,7 +14,8 @@ use windows_sys::{
     Win32::{
         Foundation::{
             CloseHandle, GetLastError, ERROR_ACCESS_DENIED, ERROR_ELEVATION_REQUIRED,
-            ERROR_INVALID_PARAMETER, ERROR_NOT_ALL_ASSIGNED, FALSE, HANDLE, LUID, TRUE,
+            ERROR_INVALID_PARAMETER, ERROR_NOT_ALL_ASSIGNED, FALSE, HANDLE, INVALID_HANDLE_VALUE,
+            LUID, TRUE,
         },
         Security::{
             AdjustTokenPrivileges, DuplicateTokenEx, EqualSid, GetTokenInformation,
@@ -453,7 +454,7 @@ impl OwnedHandle {
     }
 
     fn is_invalid(&self) -> bool {
-        self.0.is_null()
+        self.0.is_null() || self.0 == INVALID_HANDLE_VALUE
     }
 }
 
@@ -480,8 +481,8 @@ impl DerefMut for OwnedHandle {
 }
 
 struct RevertPrivilegeOnDrop {
-    process: *mut c_void,
-    privilege: *const u16,
+    process: HANDLE,
+    privilege: PCWSTR,
     previous_state: bool,
 }
 
@@ -516,7 +517,7 @@ mod tests {
 
     #[test]
     fn spawn_cmd() {
-        unsafe { run_as_user("cmd", "/c timeout 3") };
+        assert!(unsafe { run_as_user(r"C:\Windows\System32\cmd.exe", "/c timeout 3") });
     }
 
     #[test]
@@ -524,21 +525,20 @@ mod tests {
     fn spawn_with_spaces() {
         extern crate std;
         use alloc::format;
-        use alloc::string::ToString;
 
         let current = std::env::current_dir().unwrap();
 
         let dir = current.join("dir space");
         std::fs::create_dir_all(&dir).unwrap();
 
-        let systemroot = std::env::var("SYSTEMROOT").unwrap_or_else(|_| "C:\\Windows".to_owned());
+        let systemroot = std::env::var("SYSTEMROOT").unwrap_or_else(|_| r"C:\Windows".to_owned());
 
-        let cmd = format!("{systemroot}\\System32\\cmd.exe");
+        let cmd = format!(r"{systemroot}\System32\cmd.exe");
         let cmd_out = dir.join("cmdout.exe");
 
         std::fs::copy(cmd, &cmd_out).unwrap();
 
-        assert!(unsafe { run_as_user(cmd_out.display().to_string().as_str(), "/c timeout 3") });
+        assert!(unsafe { run_as_user(cmd_out.to_str().unwrap(), "/c timeout 3") });
 
         std::thread::sleep(std::time::Duration::from_secs(5));
         std::fs::remove_file(cmd_out).unwrap();

--- a/demo.nsi
+++ b/demo.nsi
@@ -3,6 +3,8 @@ OutFile "demo.exe"
 Unicode true
 ShowInstDetails show
 
+; RequestExecutionLevel user
+
 !addplugindir ".\target\i686-pc-windows-msvc\release"
 !addplugindir "$%CARGO_TARGET_DIR%\i686-pc-windows-msvc\release"
 !addplugindir "$%CARGO_BUILD_TARGET_DIR%\i686-pc-windows-msvc\release"
@@ -22,7 +24,7 @@ Section
     nsis_process::FindProcess "abcdef.exe"
     Pop $1
     DetailPrint "FindProcess(abcdef.exe): $1"
-    nsis_process::RunAsUser "C:\\Windows\\System32\\cmd.exe" "/c timeout 3"
+    nsis_process::RunAsUser "C:\Windows\System32\cmd.exe" "/c timeout 3"
     Pop $1
     DetailPrint "RunAsUser(cmd, /c timeout 3): $1"
 SectionEnd


### PR DESCRIPTION
Also switching to use absolute path here since that's what `CreateProcessWithTokenW` needs